### PR TITLE
Switch to config file for sync configuration, add complex options

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-runtime": "^6.11.6",
     "dotenv": "^4.0.0",
     "isomorphic-fetch": "^2.2.1",
+    "js-yaml": "^3.7.0",
     "ts-progress": "^0.0.10",
     "update-notifier": "^1.0.2",
     "xml2js": "^0.4.17"

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,46 @@
+import yaml from 'js-yaml';
+import fs from 'fs';
+
+export const TOKEN = process.env.PLEX_TOKEN;
+
+const DEFAULT_CONFIG = {
+  rules: [],
+};
+
+export const loadConfig = (filename) => {
+  try {
+    const config = yaml.safeLoad(fs.readFileSync(filename, 'utf8'));
+    return config;
+  } catch (e) {
+    return { ...DEFAULT_CONFIG };
+  }
+};
+
+export const validateConfig = () => {};
+
+export const oldCLIArgsToConfig = (args) => {
+  const rules = args.map((arg) => {
+    const matches = arg.match(/^((https?):\/\/)?(([^@]+)@)?(([^:]+)(:(\d+))?)\/(\d+)(,[rw][rw]?)?$/);
+    if (!matches) return null;
+    const protocol = matches[2] === 'https' ? 'https' : 'http';
+    const token = matches[4];
+    const host = matches[6];
+    const port = parseInt(matches[8] || '32400', 10);
+    const section = parseInt(matches[9] || '1', 10);
+    const modeString = matches[10] || 'rw';
+    const read = modeString.includes('r');
+    const write = modeString.includes('w');
+
+    const rule = { host, section };
+
+    if (protocol !== 'http') rule.protocol = protocol;
+    if (port !== 32400) rule.port = port;
+    if (token) rule.token = token;
+    if (!read) rule.read = read;
+    if (!write) rule.write = write;
+
+    return rule;
+  }).filter(rule => rule);
+
+  return yaml.safeDump({ default: { rules } });
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import updateNotifier from 'update-notifier';
 
-import { exitUsage, log, parseCLIArg, progressMap } from './ui';
+import { exitNewConfig, exitUsage, log, parseCLIArg, progressMap } from './ui';
 import { fetchMovies, markWatched } from './plex';
 import pkg from '../package.json';
 
@@ -10,6 +10,10 @@ updateNotifier({ pkg }).notify();
 
 const DRY_RUN = !!process.env.DRY_RUN;
 const FUZZY = (process.env.MATCH_TYPE || 'fuzzy') === 'fuzzy';
+
+if (process.argv.length > 2) {
+  exitNewConfig();
+}
 
 if (process.argv.length < 4) {
   exitUsage();

--- a/src/ui.js
+++ b/src/ui.js
@@ -2,6 +2,8 @@
 
 import Progress from 'ts-progress';
 
+import { oldCLIArgsToConfig } from './config';
+
 export const log = (...args) => console.error(...args);
 
 export const TOKEN = process.env.PLEX_TOKEN;
@@ -37,6 +39,17 @@ Example:
     Complex use case:
     $ plex-sync xxxx@10.0.1.5:32401/1,r https://yyyy@10.0.1.10/3,w zzzz@10.0.1.15/2,rw
 `.trim());
+  process.exit(1);
+};
+
+export const exitNewConfig = () => {
+  console.error(`
+plex-sync uses a new YAML-based configuration format - create a file with the
+following contents and run 'plex-sync [config-file]':
+
+`.trim());
+  console.error();
+  console.error(oldCLIArgsToConfig(process.argv.slice(2)));
   process.exit(1);
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1765,7 +1765,7 @@ js-tokens@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.0.tgz#a2f2a969caae142fb3cd56228358c89366957bd1"
 
-js-yaml@^3.5.1:
+js-yaml@^3.5.1, js-yaml@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:


### PR DESCRIPTION
The goal is to support defining multiple sync settings inside one config file, as well as enable the ability to sync partial watch status, require a certain number of servers to report watched, etc.